### PR TITLE
Set grace termination period of testrunners pod to 0

### DIFF
--- a/amq/src/test/resources/testrunner-pod.json
+++ b/amq/src/test/resources/testrunner-pod.json
@@ -9,6 +9,7 @@
 	},
 
 	"spec": {
+		"terminationGracePeriodSeconds": 0,
 		"containers": [
 			{
 				"name": "testrunner",

--- a/decisionserver/src/test/resources/testrunner-pod.json
+++ b/decisionserver/src/test/resources/testrunner-pod.json
@@ -8,6 +8,7 @@
 		}
 	},
 	"spec": {
+		"terminationGracePeriodSeconds": 0,
 		"containers": [{
 			"name": "testrunner",
 			"readinessProbe" : {

--- a/eap/eap64/src/test/resources/testrunner-pod.json
+++ b/eap/eap64/src/test/resources/testrunner-pod.json
@@ -8,6 +8,7 @@
 		}
 	},
 	"spec": {
+		"terminationGracePeriodSeconds": 0,
 		"containers": [{
 			"name": "testrunner",
 			"readinessProbe" : {

--- a/eap/integration/src/test/resources/testrunner-pod.json
+++ b/eap/integration/src/test/resources/testrunner-pod.json
@@ -9,6 +9,7 @@
   },
 
   "spec": {
+    "terminationGracePeriodSeconds": 0,
     "containers": [
       {
         "name": "testrunner",

--- a/jdg/src/test/resources/testrunner-pod.json
+++ b/jdg/src/test/resources/testrunner-pod.json
@@ -8,6 +8,7 @@
 		}
 	},
 	"spec": {
+		"terminationGracePeriodSeconds": 0,
 		"containers": [{
 			"name": "testrunner",
 			"readinessProbe" : {

--- a/webserver/src/test/resources/testrunner-pod.json
+++ b/webserver/src/test/resources/testrunner-pod.json
@@ -8,6 +8,7 @@
 		}
 	},
 	"spec": {
+		"terminationGracePeriodSeconds": 0,
 		"containers": [{
 			"name": "testrunner",
 			"readinessProbe" : {


### PR DESCRIPTION
When running multiple tests, a race condition might happen between
them: When a test finishes, it deletes the testrunner pod. When a
test starts, it creates a testrunner pod. Sometimes this creation
fails because the testrunner pod from previous test was not entirely
removed. It is in process of deletion.

By setting the graceful shutdown period to 0 we make sure the testrunner
pod will be removed immediately, thus elimiting this race condition.