### PR TITLE
EAP Clustering: Run tests in sequence

### DIFF
--- a/eap/common/src/main/java/org/jboss/test/arquillian/ce/eap/common/EapClusteringTestBase.java
+++ b/eap/common/src/main/java/org/jboss/test/arquillian/ce/eap/common/EapClusteringTestBase.java
@@ -17,6 +17,7 @@ import org.jboss.arquillian.ce.httpclient.HttpClientBuilder;
 import org.jboss.arquillian.ce.httpclient.HttpRequest;
 import org.jboss.arquillian.ce.httpclient.HttpResponse;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -61,6 +62,7 @@ public class EapClusteringTestBase {
      */
     @Test
     @RunAsClient
+    @InSequence(1)
     public void testSession() throws Exception {
         // Start with 2 pods
         scale(2);

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64ClusteringTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64ClusteringTest.java
@@ -10,6 +10,7 @@ import org.jboss.arquillian.ce.api.TemplateParameter;
 import org.jboss.arquillian.ce.cube.RouteURL;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.test.arquillian.ce.eap.common.EapClusteringTestBase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,6 +50,7 @@ public class Eap64ClusteringTest extends EapClusteringTestBase {
      */
     @Test
     @RunAsClient
+    @InSequence(2)
     public void testLongRequest(@RouteURL("eap-app") URL url) throws Exception {
         final int DELAY_BETWEEN_REQUESTS = 5;
         final String serviceUrl = url.toString();


### PR DESCRIPTION
To avoid race conditions, once tests scale up and down deployments, one
test might interfere on other.

So, let's run them sequencially.