### PR TITLE
[daikon] Spark: An arquillian spark smoke test to get things started for xpass.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,52 @@
 		</plugins>
 	</build>
 
-	<dependencyManagement>
+ 	<!--	Some artifacts, like
+		infinispan-remote-query-client/6.3.1.Final-redhat-1/infinispan-remote-query-client-6.3.1.Final-redhat-1.pom
+		and so on, will need these. -->
+		<repositories>
+			<repository>
+				<id>jboss-public-repository-group</id>
+				<name>JBoss Public Maven Repository Group</name>
+				<url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+				<layout>default</layout>
+				<releases>
+					<enabled>true</enabled>
+					<updatePolicy>never</updatePolicy>
+				</releases>
+				<snapshots>
+					<enabled>true</enabled>
+					<updatePolicy>always</updatePolicy>
+				</snapshots>
+			</repository>
+		<!-- <repository> <id>1rhat</id> <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url> </repository> -->
+		<repository>
+			<id>2rhat</id>
+			<url>https://maven.repository.redhat.com/techpreview/all/</url>
+		</repository>
+
+		<repository>
+			<id>3rhat</id>
+			<url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+		</repository>
+		<!-- <repository> <id>4rhat</id> <url>https://repository.jboss.org/</url> </repository> -->
+		<repository>
+			<id>5rhat</id>
+			<url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
+		</repository>
+		<repository>
+			<id>6rhat</id>
+			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+		</repository>
+		<repository>
+			<id>7rhat</id>
+			<url>https://repository.jboss.org/nexus/content/repositories/thirdparty-uploads/</url>
+		</repository>
+		<!-- <repository> <id>8rhat</id> <url>http://repository.jboss.org/nexus/content/groups/developer/</url> </repository> -->
+	</repositories>
+
+ 	<dependencyManagement>
+
 		<dependencies>
 
 			<dependency>

--- a/spark/README.md
+++ b/spark/README.md
@@ -1,0 +1,9 @@
+This is a spark testing module.
+
+You can run it like so:
+
+`mvn clean package test -Pspark -Dkubernetes.master=https://ce-os-rhel-master.usersys.redhat.com:8443 -Dkubernetes.registry.url=https://ce-os-rhel-master.usersys.redhat.com:5001 -Ddocker.url=https://ce-os-rhel-master.usersys.redhat.com:2375 -Dtest=SparkTest -Dkubernetes.ignore.cleanup=true -Dsurefire.useFile=false -DtrimStackTrace=false  -Dkubernetes.namespace=my-ns-for-testing`
+
+This of course assumes you have an openshift cluster running at the above (10.1....) address, and that you have run `oc login` so that you can submit openshift pods.
+
+That container can then uses DNS to connect to spark services, the web ui, launch jobs, and so on.

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Parent -->
+    <parent>
+        <groupId>org.jboss.ce.testsuite</groupId>
+        <artifactId>parent-ce</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Artifact Configuration -->
+    <artifactId>spark-ce-testsuite</artifactId>
+    <packaging>jar</packaging>
+    <name>Spark CE Testsuite</name>
+    <description>Spark Cloud Enablement Testsuite</description>
+
+    <dependencies>
+
+        <!-- Tests - add any external existing tests here -->
+
+        <!-- EAP testunit deps -->
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <!-- Test Utils -->
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-ce-shrinkwrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-ce-fabric8</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-ce-cube</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-arquillian-container-remote</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.10</artifactId>
+          <version>2.0.0-preview</version>
+    	    <exclusions>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.core</artifactId>
+                    <groupId>jackson-databind</groupId>
+                </exclusion>
+<!--		<exclusion>
+		    <artifactId>org.glassfish.jersey.core</artifactId>
+		    <groupId>jersey-server</groupId>
+            	</exclusion>
+		<exclusion>
+		    <artifactId>org.glassfish.jersey.containers</artifactId>
+		    <groupId>jersey-container-servlet</groupId>
+		</exclusion>
+		<exclusion>
+		    <artifactId>org.glassfish.jersey.containers</artifactId>
+		    <groupId>jersey-container-servlet-core</groupId>
+		</exclusion>	
+-->	   </exclusions>
+        </dependency>
+
+        <!--  TODO Spark exclusion should be sufficient to make arquillian work.
+              But for some reason, explicit inclusion fixes everythin.
+        -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.0.rc1</version>
+        </dependency>
+
+    </dependencies>
+
+    <profiles>
+        <!-- Default, compile tests, but not run -->
+        <profile>
+            <id>default</id>
+
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+
+            <properties>
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+
+        <!-- Run tests against wildfly -->
+        <profile>
+            <id>spark</id>
+
+            <activation>
+                <property>
+                    <name>spark</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <version>${version.dependency.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>unpack-dependencies</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <includeGroupIds>org.jboss</includeGroupIds>
+                                    <includeTypes>test-jar</includeTypes>
+                                    <includeScope>test</includeScope>
+                                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                                    <overWriteReleases>false</overWriteReleases>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                        <configuration>
+                            <runOrder>alphabetical</runOrder>
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <includes>
+                                <include>org/jboss/**/*Test.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <!-- Custom DNS resolver for OpenShift routes -->
+                                <sun.net.spi.nameservice.provider.1>dns,CEArquillianNameService</sun.net.spi.nameservice.provider.1>
+                                <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
+                                <kubernetes.master>${kubernetes.master}</kubernetes.master>
+                                <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
+                                <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>
+
+
+
+

--- a/spark/src/test/java/org/jboss/test/arquillian/ce/spark/SparkTest.java
+++ b/spark/src/test/java/org/jboss/test/arquillian/ce/spark/SparkTest.java
@@ -1,0 +1,104 @@
+package org.jboss.test.arquillian.ce.spark;
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import org.jboss.arquillian.ce.api.*;
+import org.jboss.arquillian.ce.shrinkwrap.Libraries;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static junit.framework.Assert.assertEquals;
+
+import java.net.URL;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.ce.api.OpenShiftHandle;
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.api.RoleBinding;
+import org.jboss.arquillian.ce.api.Template;
+import org.jboss.arquillian.ce.api.TemplateParameter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@Template(
+        url="https://gist.githubusercontent.com/jayunit100/3fad23e42a22e473fff7a45947bd3102/raw/ccedbb3020d98267753ba758c9f739d587b3aae5/xpass-spark",
+        labels = "app=spark",
+        parameters = {
+                @TemplateParameter(name = "MASTER_NAME", value="jspark"),
+        }
+)
+@RoleBinding(roleRefName = "view", userName = "system:serviceaccount:${kubernetes.namespace}:jdg-service-account")
+public class SparkTest {
+    private static final Logger log = Logger.getLogger("spark-smoke");
+
+    // New arquillian developer note...
+    // To confirm that this test is working as expected, modify this to "201" and a failure will result in test failure.
+    // Thus, you can confirm for yourself that assertions in the container are cascading into the overall build result.
+    public static int WEB_UI_EXPECT=200;
+    
+    static{
+        System.out.println("Web ui == " + WEB_UI_EXPECT);
+    }
+    @ArquillianResource
+    ConfigurationHandle configuration;
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "run-in-pod.war");
+        war.setWebXML(new StringAsset("<web-app/>"));
+	war.addPackage(org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.class.getPackage());
+	 war.addPackage(Arquillian.class.getPackage());     
+   war.addPackage(SparkTest.class.getPackage());
+        return war;
+    }
+
+    @Test
+    @InSequence(1)
+    public void testSparkWebUI() throws Exception {
+        URL u = new URL("http://jspark-webui:8080");
+        HttpURLConnection huc =  (HttpURLConnection)  u.openConnection();
+        System.out.println(huc.getResponseCode());
+        assertEquals(WEB_UI_EXPECT,huc.getResponseCode());
+    }
+}

--- a/spark/src/test/resources/arquillian.xml
+++ b/spark/src/test/resources/arquillian.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source
+  Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+  contributors by the @authors tag. See the copyright.txt in the
+  distribution for a full listing of individual contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+          http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  
+    <!-- Uncomment to have test archives exported to the file system for inspection -->
+    <!--
+    <engine>
+	         <property name="deploymentExportPath">target/arquillian</property>
+    </engine>
+    -->
+    <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
+    <defaultProtocol type="jmx-as7" />
+    
+    <extension qualifier="ce-cube">
+        <property name="kubernetesNamespacePrefix">cearq-spark</property>
+    </extension>
+  
+    <!-- Example configuration for arquillian openshift extension -->
+    <extension qualifier="openshift">
+        <!-- Properties describing the location of the OpenShift instance.
+        <property name="originServer">https://your-ose-instance.com:8443</property>
+        <property name="namespace">test-namespace</property>
+        -->
+        <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
+        <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
+        <!-- Ports to be proxied locally, <container>:<port> -->
+        <property name="proxiedContainerPorts">testrunner:9999,testrunner:9990,testrunner:8080</property>
+    </extension>
+
+    <!--
+      class mode causes the test pod to be recreated for each test class. this
+      is required to pickup environment variables specific to the test
+      environment, e.g. service host, port, etc.  testrunner relates to the pod
+      name in testrunner-pod.json.
+    -->
+    <container qualifier="testrunner" mode="class" default="true">
+        <!-- Pod running remote tests. -->
+        <configuration>
+            <!-- For use with archillian-chameleon -->
+            <property name="target">jboss eap:6.4.5:remote</property>
+            <property name="username">admin</property>
+            <property name="password">Admin#70365</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/spark/src/test/resources/testrunner-pod.json
+++ b/spark/src/test/resources/testrunner-pod.json
@@ -1,0 +1,66 @@
+{
+	"apiVersion":"v1",
+	"kind": "Pod",
+	"metadata": {
+		"name": "testrunner",
+		"labels": {
+			"name": "testrunner"
+		}
+	},
+	"spec": {
+		"terminationGracePeriodSeconds": 0,
+		"containers": [{
+			"name": "testrunner",
+			"readinessProbe" : {
+				"exec": {
+					"command": [
+					    "/bin/bash",
+					    "-c",
+					    "curl -s --digest -L http://localhost:9990/management --header \"Content-Type: application/json\" -d '{\"operation\":\"read-attribute\",\"name\":\"server-state\",\"json.pretty\":1}' | grep -iq running"
+					]
+				}
+			},
+			"image": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.2",
+            "ports": [
+                {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                },
+                {
+                    "containerPort": 9990,
+                    "protocol": "TCP"
+                },
+                {
+                    "containerPort": 9999,
+                    "protocol": "TCP"
+                }
+            ],
+            "env": [
+                {
+                	"name": "ADMIN_USERNAME",
+                	"value": "admin"
+                },
+                {
+                	"name": "ADMIN_PASSWORD",
+                	"value": "Admin#70365"
+                },
+				{
+					"name": "NSS_WRAPPER_PASSWD",
+					"value": "/tmp/passwd"
+				},
+				{
+					"name": "NSS_WRAPPER_GROUP",
+					"value": "/etc/group"
+				},
+				{
+					"name":"LD_PRELOAD",
+					"value":"libnss_wrapper.so"
+				},
+				{
+					"name":"SPARK_USER",
+					"value":"jayunit100"
+				}
+            ]
+		}]
+	}
+}


### PR DESCRIPTION
This is a first spark smoke test using a slight variant of the xpaas spark template (adds top level labels).
It tests the Web UI since that is the fastest validation of basic spark startup.
I'm going to add the spark job tests as well.