### PR TITLE
Comment out broken modules for now

### DIFF
--- a/eap/pom.xml
+++ b/eap/pom.xml
@@ -24,9 +24,9 @@
     <modules>
         <module>common</module>
         <module>eap64</module>
-        <module>eap70</module>
-        <module>compat</module>
-        <module>integration/eap6</module>
-        <module>integration/eap7</module>
+        <!-- <module>eap70</module> -->
+        <!-- <module>compat</module> -->
+        <!-- <module>integration/eap6</module> -->
+        <!-- <module>integration/eap7</module> -->
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,13 @@
     </properties>
 
     <modules>
-        <module>amq</module>
+        <!-- <module>amq</module> -->
         <module>eap</module>
-        <module>jdg</module>
-        <module>kieserver</module>
-        <module>spark</module>
-        <module>sso</module>
-        <module>webserver</module>
+        <!-- <module>jdg</module> -->
+        <!-- <module>kieserver</module> -->
+        <!-- <module>spark</module> -->
+        <!-- <module>sso</module> -->
+        <!-- <module>webserver</module> -->
     </modules>
 
     <build>


### PR DESCRIPTION
Only eap64 and eap70 are building fine right now.

As soon as other modules are fixed they can be put
back into the game.