### PR TITLE
Removed dependency on tests-ce-testsuite artifact

### DIFF
--- a/eap/integration/eap6/pom.xml
+++ b/eap/integration/eap6/pom.xml
@@ -393,12 +393,6 @@
 
         <!-- Tests - add any external existing tests here -->
         <dependency>
-            <groupId>org.jboss.ce.testsuite</groupId>
-            <artifactId>tests-ce-testsuite</artifactId>
-            <type>test-jar</type>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-ts-integ-basic</artifactId>
             <type>test-jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -191,13 +191,6 @@
 
             <dependency>
                 <groupId>org.jboss.ce.testsuite</groupId>
-                <artifactId>tests-ce-testsuite</artifactId>
-                <type>test-jar</type>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.ce.testsuite</groupId>
                 <artifactId>wildfly-ce-testsuite</artifactId>
                 <type>test-jar</type>
                 <version>${project.version}</version>


### PR DESCRIPTION
No one depends on that. In fact it will (very probably) be removed
soon.

This allows integration tests for EAP6 to run.