### PR TITLE
Makes eap7 integration test to actually run

### DIFF
--- a/eap/integration/eap7/src/test/resources/arquillian.xml
+++ b/eap/integration/eap7/src/test/resources/arquillian.xml
@@ -50,6 +50,9 @@
       name in testrunner-pod.json.
     -->
     <container qualifier="testrunner-eap7" mode="suite" default="true">
+        <protocol type="jmx-as7">
+            <property name="executionType">REMOTE</property>
+        </protocol>
         <configuration>
             <!-- For use with archillian-chameleon -->
             <property name="target">jboss eap:7.0.0.GA:remote</property>

--- a/eap/integration/eap7/src/test/resources/testrunner-pod.json
+++ b/eap/integration/eap7/src/test/resources/testrunner-pod.json
@@ -40,10 +40,6 @@
             "protocol": "TCP"
           },
           {
-            "containerPort": 8443,
-            "protocol": "TCP"
-          },
-          {
             "containerPort": 8181,
             "protocol": "TCP"
           },


### PR DESCRIPTION
Currently they aren't running as the testrunner pod is
not deployed in the right way.

Two fixes here:
 - Fix the arquillian deployment for the jmx-as7 protocol.
 - Remove the pod's port 8443. It's used by openshift cluster. It was
   causing a clash, preventing the port forward to be executed properly
   and therefore blocking the arquillian deployment.