### PR TITLE
Use an 7.0.2 image for eap7 integration tests

### DIFF
--- a/eap/integration/eap7/src/test/resources/testrunner-pod.json
+++ b/eap/integration/eap7/src/test/resources/testrunner-pod.json
@@ -33,7 +33,7 @@
             }
           }
         },
-        "image": "jboss-eap-7/eap70-openshift:1.4",
+        "image": "jboss-eap-7/eap70-openshift:1.4-13",
         "ports": [
           {
             "containerPort": 8080,


### PR DESCRIPTION
Because EAP versions greater than 7.0.2 have an issue
with EJB, making some tests fail.

(See https://issues.jboss.org/browse/JBEAP-7318)

So, as a workaround, let's use an older image that ships
EAP 7.0.2 and therefore tests will pass.

The proper fix is to use a fixed - and newer - image as
soon as it becomes available.

This is a workaround for #116.