### PR TITLE
Revert "Use an 7.0.2 image for eap7 integration tests"

### DIFF
--- a/eap/integration/eap7/src/test/resources/testrunner-pod.json
+++ b/eap/integration/eap7/src/test/resources/testrunner-pod.json
@@ -33,7 +33,7 @@
             }
           }
         },
-        "image": "jboss-eap-7/eap70-openshift:1.4-13",
+        "image": "jboss-eap-7/eap70-openshift:1.4",
         "ports": [
           {
             "containerPort": 8080,


### PR DESCRIPTION
Reverts jboss-openshift/ce-testsuite#117

As discussed with @rcernich, we will instead disable specific tests via pom.xml and keep the version.