### PR TITLE
Enable kieserver 6.3 tests - and do small improvements

### DIFF
--- a/kieserver/62/src/test/resources/arquillian.xml
+++ b/kieserver/62/src/test/resources/arquillian.xml
@@ -54,7 +54,6 @@
         <!-- Pod running remote tests. -->
         <configuration>
             <!-- For use with archillian-chameleon -->
-            <property name="target">jboss eap:6.4.5:remote</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>

--- a/kieserver/62/src/test/resources/testrunner-pod.json
+++ b/kieserver/62/src/test/resources/testrunner-pod.json
@@ -16,11 +16,11 @@
 					"command": [
 					    "/bin/bash",
 					    "-c",
-					    "curl -s --digest -L http://localhost:9990/management --header \"Content-Type: application/json\" -d '{\"operation\":\"read-attribute\",\"name\":\"server-state\",\"json.pretty\":1}' | grep -iq running"
+					    "/opt/eap/bin/readinessProbe.sh"
 					]
 				}
 			},
-			"image": "jboss-eap-6/eap64-openshift:1.2",
+			"image": "jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,

--- a/kieserver/63/src/test/resources/arquillian.xml
+++ b/kieserver/63/src/test/resources/arquillian.xml
@@ -54,7 +54,6 @@
         <!-- Pod running remote tests. -->
         <configuration>
             <!-- For use with archillian-chameleon -->
-            <property name="target">jboss eap:6.4.5:remote</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>

--- a/kieserver/63/src/test/resources/testrunner-pod.json
+++ b/kieserver/63/src/test/resources/testrunner-pod.json
@@ -16,11 +16,11 @@
 					"command": [
 					    "/bin/bash",
 					    "-c",
-					    "curl -s --digest -L http://localhost:9990/management --header \"Content-Type: application/json\" -d '{\"operation\":\"read-attribute\",\"name\":\"server-state\",\"json.pretty\":1}' | grep -iq running"
+					    "/opt/eap/bin/readinessProbe.sh"
 					]
 				}
 			},
-			"image": "jboss-eap-6/eap64-openshift:1.2",
+			"image": "jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,

--- a/kieserver/pom.xml
+++ b/kieserver/pom.xml
@@ -20,9 +20,9 @@
 
     <modules>
         <module>62</module>
-        <!-- <module>63</module> -->
+        <module>63</module>
     </modules>
-    
+
     <properties>
         <version.jboss.bom.brms>6.2.0.GA-redhat-1</version.jboss.bom.brms>
         <version.org.kie>6.2.0.Final-redhat-14</version.org.kie>


### PR DESCRIPTION
 - Use newest images for eap64: 1.4
 - Use the proper readiness probe script
 - Drop an unsed propert ("target") in arquillian.xml