### PR TITLE
rollingUpgrade() got renamed to triggerDeploymentConfigUpdate()

### DIFF
--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqRollingUpgradeTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqRollingUpgradeTest.java
@@ -87,7 +87,7 @@ public class AmqRollingUpgradeTest extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(3)
     public void testRollingUpdate(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.rollingUpgrade("amq-test-amq", true);
+        adapter.triggerDeploymentConfigUpdate("amq-test-amq", true);
     }
 
     @Test


### PR DESCRIPTION
in ce-arq, this is breaking the build.