### PR TITLE
Use jboss-logging 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <version.jolokia>1.3.4</version.jolokia>
         <version.json>20160212</version.json>
         <!-- EAP testunit deps -->
-        <version.logging>3.1.4.GA</version.logging>
+        <version.logging>3.2.1.Final</version.logging>
         <version.httpclient>4.3.6.redhat-1</version.httpclient>
         <version.org.jboss.xnio>3.3.1.Final</version.org.jboss.xnio>
         <version.syslog4j>0.9.30</version.syslog4j>


### PR DESCRIPTION
As it's the same version used in Undertow.

This avoids errors like:

java.lang.NoSuchMethodError: io.undertow.UndertowLogger.tracef(Ljava/lang/String;JJ)V