### PR TITLE
Quieten couple of junit.framework deprecation warnings in the webserver test suite

### DIFF
--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java
@@ -38,7 +38,6 @@ import javax.websocket.MessageHandler;
 import javax.websocket.Session;
 import javax.websocket.WebSocketContainer;
 
-import junit.framework.Assert;
 import org.jboss.arquillian.ce.api.OpenShiftHandle;
 import org.jboss.arquillian.ce.api.Tools;
 import org.jboss.arquillian.ce.httpclient.HttpClientBuilder;
@@ -47,6 +46,7 @@ import org.jboss.arquillian.ce.httpclient.HttpResponse;
 import org.jboss.arquillian.ce.shrinkwrap.Libraries;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 
 /**
  * @author fspolti


### PR DESCRIPTION
Fixes couple of ```junit.framework``` deprecation warnings, e.g.:
```
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[41,23] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[41,23] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[41,23] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[142,9] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[168,9] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[182,9] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[185,9] junit.framework.Assert in junit.framework has been deprecated
[WARNING] /tmp/github/ce-testsuite/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebserverTestBase.java:[186,9] junit.framework.Assert in junit.framework has been deprecated
```
as seen when running some Arq test for JBoss Webserver product.

Please review.

Thank you, Jan