### PR TITLE
Fix AmqExternalAccess tests

### DIFF
--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqSslTestBase.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqSslTestBase.java
@@ -5,20 +5,16 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.SslContext;
 import org.apache.qpid.jms.transports.TransportSslOptions;
 import org.apache.qpid.jms.transports.TransportSupport;
 import org.jboss.arquillian.ce.shrinkwrap.Libraries;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
 import org.junit.Before;
 
 public class AmqSslTestBase extends AmqTestBase {
 	
 	static Logger LOG = Logger.getLogger(AmqSslTestBase.class.getName());
-
-	private BrokerService svc;
 
     private SslContext brokerContext;
 
@@ -30,33 +26,11 @@ public class AmqSslTestBase extends AmqTestBase {
 
     @Before
     public void setUp() throws Exception {
-        svc = createBroker();
         TransportSslOptions sslOptions = createTransportSslOptions();
 
         SSLContext ssl = TransportSupport.createSslContext(sslOptions);
         SSLContext.setDefault(ssl);
-
-        final SslContext brokerContext = createBrokerContext(ssl);
-        svc.setSslContext(brokerContext);
-
-        svc.addConnector("ssl://localhost:0");
-        svc.start();
-        svc.waitUntilStarted();
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        svc.stop();
-        svc.waitUntilStopped();
-    }
-
-    public BrokerService createBroker() {
-        BrokerService brokerService = new BrokerService();
-        brokerService.setPersistent(false);
-        brokerService.setAdvisorySupport(false);
-        brokerService.setDeleteAllMessagesOnStartup(true);
-        brokerService.setUseJmx(false);
-        return brokerService;
+        createBrokerContext(ssl);
     }
 
     public TransportSslOptions createTransportSslOptions() {


### PR DESCRIPTION
By not creating a broker. We don't need a server within the client
code. Only on the server.