### PR TITLE
Fix in AmqSourceToImageTest

### DIFF
--- a/amq/src/test/resources/amq62-s2i.json
+++ b/amq/src/test/resources/amq62-s2i.json
@@ -278,7 +278,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
-                            "name": "jboss-amq-62:1.2"
+                            "name": "jboss-amq-62:1.4"
                         }
                     }
                 },


### PR DESCRIPTION
By updating BuildConfig base image to run the builds. The version is very outdated.