### PR TITLE
Remove the testLibraryAMQ from LibraryProcessTestBase

### DIFF
--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/LibraryProcessTestBase.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/LibraryProcessTestBase.java
@@ -61,11 +61,6 @@ public abstract class LibraryProcessTestBase extends KieServerTestBase {
     }
 
     @Test
-    public void testLibraryAMQ() throws Exception {
-        runLibraryTest(configureAmqClient());
-    }
-
-    @Test
     public void testLibraryREST() throws Exception {
         runLibraryTest(configureRestClient(new URL("http://" + System.getenv("KIE_APP_SERVICE_HOST") + ":" + System.getenv("KIE_APP_SERVICE_PORT") + "/")));
     }

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerMySqlPersistentTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerMySqlPersistentTest.java
@@ -72,11 +72,6 @@ public class ProcessServerMySqlPersistentTest extends LibraryProcessTestBase {
                 return routeURL;
         }
 
-        @Override
-        public void testLibraryAMQ() throws Exception {
-                // do nothing on non amq templates
-        }
-
         @Test
         @RunAsClient
         public void testProcessServerCapabilities() throws Exception {

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerMySqlTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerMySqlTest.java
@@ -72,11 +72,6 @@ public class ProcessServerMySqlTest extends LibraryProcessTestBase {
                 return routeURL;
         }
 
-        @Override
-        public void testLibraryAMQ() throws Exception {
-                // do nothing on non amq templates
-        }
-
         @Test
         @RunAsClient
         public void testProcessServerCapabilities() throws Exception {

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerPostgreSqlPersistentTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerPostgreSqlPersistentTest.java
@@ -70,11 +70,6 @@ public class ProcessServerPostgreSqlPersistentTest extends LibraryProcessTestBas
                 return routeURL;
         }
 
-        @Override
-        public void testLibraryAMQ() throws Exception {
-                // do nothing on non amq templates
-        }
-
         @Test
         @RunAsClient
         public void testProcessServerCapabilities() throws Exception {

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerPostgreSqlTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/processserver/ProcessServerPostgreSqlTest.java
@@ -70,11 +70,6 @@ public class ProcessServerPostgreSqlTest extends LibraryProcessTestBase {
                 return routeURL;
         }
 
-        @Override
-        public void testLibraryAMQ() throws Exception {
-                // do nothing on non amq templates
-        }
-
         @Test
         @RunAsClient
         public void testProcessServerCapabilities() throws Exception {


### PR DESCRIPTION
This test does not instantiate the AMQ template and there is
another test that already do this.