### PR TITLE
Drop the usage of "router.hostIP" system property

### DIFF
--- a/amq/pom.xml
+++ b/amq/pom.xml
@@ -190,7 +190,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/eap/eap64/pom.xml
+++ b/eap/eap64/pom.xml
@@ -140,7 +140,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/eap/eap70/pom.xml
+++ b/eap/eap70/pom.xml
@@ -134,7 +134,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                         <template.repository>jboss-openshift</template.repository>
                         <template.branch>master</template.branch>
                     </systemPropertyVariables>

--- a/jdg/jdg65/pom.xml
+++ b/jdg/jdg65/pom.xml
@@ -156,7 +156,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/kieserver/62/pom.xml
+++ b/kieserver/62/pom.xml
@@ -139,7 +139,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/kieserver/63/pom.xml
+++ b/kieserver/63/pom.xml
@@ -158,7 +158,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                         <template.repository>jboss-openshift</template.repository>
                         <template.branch>master</template.branch>
                     </systemPropertyVariables>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -143,7 +143,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -129,7 +129,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -130,7 +130,6 @@
                         <sun.net.spi.nameservice.provider.2>default</sun.net.spi.nameservice.provider.2>
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
-                        <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
We already have the property "openshift.router.host" with the
same purpose. Better yet, it can be replaced by an env variable
"OPENSHIFT_ROUTER_HOST". It's up to the user to choose between
them.

Having another system property might lead to some confusion.

We should also update our doc (currently README's) to reflect
that. As they are outdated, it makes sense to fix them along
with the other necessary changes. An issue is open for that
(https://github.com/jboss-openshift/ce-testsuite/issues/138)