### PR TITLE
Don't set "failIfNoTests" to true.

### DIFF
--- a/jdg/integration/pom.xml
+++ b/jdg/integration/pom.xml
@@ -252,7 +252,6 @@
                     <runOrder>alphabetical</runOrder>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
-                    <failIfNoTests>true</failIfNoTests>
                     <excludedGroups>${groups.unstable}</excludedGroups>
                     <includes>
                         <include>**/*IT.java</include>


### PR DESCRIPTION
If we want to run specific tests from the root dir (passing
-Dtest=...) we need this flag to be false, (via default value,
or via command line override -DfailIfNoTests=false). If there
is a module with this flas set to true, then surefire will fail
at that module, if the test is not found within it.