### PR TITLE
EAP6 Integration tests: Use '-ce' version instead of '-SNAPSHOT'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <version.arquillian>1.1.11.Final</version.arquillian>
         <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
         <version.arquillian.governor>1.0.1.Final</version.arquillian.governor>
-        <version.eap6>7.5.11.Final-redhat-SNAPSHOT</version.eap6> <!--eap 6.4.x downstream -->
+        <version.eap6>7.5.11.Final-redhat-ce</version.eap6> <!--eap 6.4.x downstream -->
         <version.eap7>7.0.3.GA-redhat-SNAPSHOT</version.eap7> <!-- eap-7 downstream-->
         <org.jboss.bom.version>7.0.0.GA</org.jboss.bom.version>
         <version.junit>4.12</version.junit>


### PR DESCRIPTION
This way we have more control of the artifacts we are depending on.
We explicitly rely on a version under our control. Specifically, this
version can be found on our nexus mirror.