### PR TITLE
Small fixes on SSO tests

### DIFF
--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -30,6 +30,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
@@ -117,7 +122,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <runOrder>alphabetical</runOrder>
-                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
                     <forkMode>once</forkMode>
                     <includes>

--- a/sso/src/test/resources/arquillian.xml
+++ b/sso/src/test/resources/arquillian.xml
@@ -54,7 +54,6 @@
         <!-- Pod running remote tests. -->
         <configuration>
             <!-- For use with archillian-chameleon -->
-            <property name="target">jboss eap:6.4.5:remote</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>

--- a/sso/src/test/resources/log4j.properties
+++ b/sso/src/test/resources/log4j.properties
@@ -12,6 +12,6 @@ log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c %3x - %m%n
 
 #Root Logger
-log4j.rootLogger=TRACE, stdout
+log4j.rootLogger=INFO, stdout
 
 log4j.logger.org.apache.http.wire=INFO

--- a/sso/src/test/resources/testrunner-pod.json
+++ b/sso/src/test/resources/testrunner-pod.json
@@ -8,7 +8,7 @@
 		}
 	},
 	"spec": {
-	    "terminationGracePeriodSeconds": 300,
+	    "terminationGracePeriodSeconds": 0,
 		"containers": [{
 			"name": "testrunner",
 			"readinessProbe" : {
@@ -16,11 +16,11 @@
 					"command": [
 					    "/bin/bash",
 					    "-c",
-					    "curl -s --digest -L http://localhost:9990/management --header \"Content-Type: application/json\" -d '{\"operation\":\"read-attribute\",\"name\":\"server-state\",\"json.pretty\":1}' | grep -iq running"
+					    "/opt/eap/bin/readinessProbe.sh"
 					]
 				}
 			},
-			"image": "jboss-eap-6/eap64-openshift:1.2",
+			"image": "jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,


### PR DESCRIPTION
 - Configure proper logging
 - Adjust testrunner pod
   - Set grace period to 0
     - For rationale see 97f2575da7 (Set grace termination period of testrunners pod to 0)
   - Use latest 6.4 image
   - Use proper readiness probe