### PR TITLE
Don't hardcode template repositories URL's

### DIFF
--- a/amq/pom.xml
+++ b/amq/pom.xml
@@ -191,6 +191,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqExternalAccessTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqExternalAccessTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-ssl.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-ssl.json",
 	parameters = {
 		@TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO,QUEUES.BAR"),
 		@TemplateParameter(name = "APPLICATION_NAME", value = "amq-test"),

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqMeshTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqMeshTest.java
@@ -51,7 +51,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-basic.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-basic.json",
     parameters = {
         @TemplateParameter(name = "APPLICATION_NAME", value = "amq-test"),
 		@TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO"),

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqPersistentSecuredTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqPersistentSecuredTest.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
  * @author Ricardo Martinelli
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-persistent-ssl.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-persistent-ssl.json",
     parameters = {
         @TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO,QUEUES.BAR"),
         @TemplateParameter(name = "MQ_TOPICS", value = "topics.mqtt"),

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqPersistentTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqPersistentTest.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
  * @author Ricardo Martinelli
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-persistent.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-persistent.json",
     parameters = {
         @TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO,QUEUES.BAR"),
         @TemplateParameter(name = "MQ_TOPICS", value = "topics.mqtt"),

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqSecuredTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqSecuredTest.java
@@ -49,7 +49,7 @@ import org.junit.runner.RunWith;
  * @author Ricardo Martinelli
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-ssl.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-ssl.json",
     parameters = {
         @TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO,QUEUES.BAR"),
         @TemplateParameter(name = "APPLICATION_NAME", value = "amq-test"),

--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqTest.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqTest.java
@@ -49,7 +49,7 @@ import org.junit.runner.RunWith;
  * @author Ricardo Martinelli
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/amq/amq62-basic.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/amq/amq62-basic.json",
     parameters = {
         @TemplateParameter(name = "MQ_QUEUES", value = "QUEUES.FOO,QUEUES.BAR"),
         @TemplateParameter(name = "APPLICATION_NAME", value = "amq-test"),

--- a/eap/eap64/pom.xml
+++ b/eap/eap64/pom.xml
@@ -141,6 +141,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64AmqTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64AmqTest.java
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
  * @author Marko Luksa
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-amq-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-amq-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64BasicTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64BasicTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  * @author Jonh Wendell
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-basic-s2i.json")
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-basic-s2i.json")
 public class Eap64BasicTest extends EapBasicTestBase {
 
 }

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64ClusteringTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64ClusteringTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertFalse;
  * @author Jonh Wendell
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-basic-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-basic-s2i.json", parameters = {
         @TemplateParameter(name = "SOURCE_REPOSITORY_URL", value = "https://github.com/jboss-openshift/openshift-examples"),
         @TemplateParameter(name = "SOURCE_REPOSITORY_REF", value = "master"),
         @TemplateParameter(name = "CONTEXT_DIR", value = "eap-tests/cluster1")})

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64HttpsTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64HttpsTest.java
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
  * @author Jonh Wendell
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-https-s2i.json",
 parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MongoDbPersistentTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MongoDbPersistentTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-mongodb-persistent-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-mongodb-persistent-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MongoDbTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MongoDbTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-mongodb-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-mongodb-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MysqlPersistentTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MysqlPersistentTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-mysql-persistent-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-mysql-persistent-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MysqlTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64MysqlTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-mysql-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-mysql-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64PostgresqlPersistentTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64PostgresqlPersistentTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-postgresql-persistent-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-postgresql-persistent-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64PostgresqlTest.java
+++ b/eap/eap64/src/test/java/org/jboss/test/arquillian/ce/eap64/Eap64PostgresqlTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-postgresql-s2i.json", parameters = {
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-postgresql-s2i.json", parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value = "jboss"),
         @TemplateParameter(name = "HTTPS_PASSWORD", value = "mykeystorepass") })
 @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/eap-app-secret.json")

--- a/jdg/jdg65/pom.xml
+++ b/jdg/jdg65/pom.xml
@@ -157,6 +157,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgBasicTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgBasicTest.java
@@ -33,7 +33,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-basic.json")
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-basic.json")
 @RoleBinding(roleRefName = "view", userName = "system:serviceaccount:${kubernetes.namespace}:jdg-service-account")
 @OpenShiftResources({
         @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/datagrid-app-secret.json")

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgHttpsTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgHttpsTest.java
@@ -34,7 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-https.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-https.json",
           parameters = {
               @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
               @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")})

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMultTempTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMultTempTest.java
@@ -94,11 +94,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @TemplateResources(syncInstantiation = true, templates = {
-		@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-basic.json", parameters = {
+		@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-basic.json", parameters = {
 				@TemplateParameter(name = "APPLICATION_NAME", value = "carcache"),
 				@TemplateParameter(name = "INFINISPAN_CONNECTORS", value = "hotrod"),
 				@TemplateParameter(name = "CACHE_NAMES", value = "carcache") }),
-		@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-basic-s2i.json", parameters = {
+		@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-basic-s2i.json", parameters = {
 				@TemplateParameter(name = "SOURCE_REPOSITORY_URL", value = "https://github.com/jboss-openshift/openshift-quickstarts"),
 				@TemplateParameter(name = "SOURCE_REPOSITORY_REF", value = "1.2"),
 				@TemplateParameter(name = "CONTEXT_DIR", value = "datagrid/carmart") }) })

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMysqlPersistentTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMysqlPersistentTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-mysql-persistent.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-mysql-persistent.json",
           parameters = {
               @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
               @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")})

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMysqlTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgMysqlTest.java
@@ -34,7 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-mysql.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-mysql.json",
           parameters = {
               @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
               @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")})

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgPostgresqlPersistentTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgPostgresqlPersistentTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-postgresql-persistent.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-postgresql-persistent.json",
           parameters = {
               @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
               @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")})

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgPostgresqlTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgPostgresqlTest.java
@@ -34,7 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-postgresql.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-postgresql.json",
           parameters = {
               @TemplateParameter(name = "HTTPS_NAME", value="jboss"),
               @TemplateParameter(name = "HTTPS_PASSWORD", value="mykeystorepass")})

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/query/JdgQueryTest.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/query/JdgQueryTest.java
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
  * @author Marko Luksa
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/datagrid/datagrid65-https.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/datagrid/datagrid65-https.json",
         labels = "application=datagrid-app",
         parameters = {
                 @TemplateParameter(name="HTTPS_NAME", value="jboss"),

--- a/kieserver/62/pom.xml
+++ b/kieserver/62/pom.xml
@@ -140,6 +140,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerAmqTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerAmqTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-amq-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-amq-s2i.json",
         parameters = {
                 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
                 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}"),

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicMulltiContainerTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicMulltiContainerTest.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-basic-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.2.0.Final|" +

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureMultiContainerTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureMultiContainerTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 //The rest of template's parameters are coming from DecisionServerBasicTest class
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-https-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.2.0.Final|" +

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureTest.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-https-s2i.json",
         parameters = {
 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}")

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-basic-s2i.json",
         parameters = {
                 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
                 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}")

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerHttpClientSecureAllInOneTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerHttpClientSecureAllInOneTest.java
@@ -42,7 +42,7 @@ import java.net.URL;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-https-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.2.0.Final|" +

--- a/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerMultiContainerAmqTest.java
+++ b/kieserver/62/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerMultiContainerAmqTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver62-amq-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver62-amq-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "HelloRulesContainer=org.openshift.quickstarts:decisionserver-hellorules:1.2.0.Final|" +

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerAmqTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerAmqTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
  * @author Filippe Spolti
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-amq-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-amq-s2i.json",
         parameters = {
                 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
                 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}"),
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
         }
 )
 @OpenShiftResources({
-    @OpenShiftResource("https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/decisionserver-app-secret.json")
+    @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/decisionserver-app-secret.json")
 })
 public class DecisionServerAmqTest extends DecisionServerTestBase {
 

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicMulltiContainerTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicMulltiContainerTest.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-basic-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "decisionserver-hellorules=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final|" +

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureMultiContainerTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureMultiContainerTest.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-https-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "decisionserver-hellorules=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final|" +

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicSecureTest.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-https-s2i.json",
         parameters = {
                 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
                 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}")

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerBasicTest.java
@@ -41,14 +41,14 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-basic-s2i.json",
         parameters = {
                 @TemplateParameter(name = "KIE_SERVER_USER", value = "${kie.username:kieserver}"),
                 @TemplateParameter(name = "KIE_SERVER_PASSWORD", value = "${kie.password:Redhat@123}")
         }
 )
 @OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/decisionserver-app-secret.json")
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/decisionserver-app-secret.json")
 })
 public class DecisionServerBasicTest extends DecisionServerTestBase {
 

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerHttpClientSecureAllInOneTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerHttpClientSecureAllInOneTest.java
@@ -42,7 +42,7 @@ import java.net.URL;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-https-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "decisionserver-hellorules=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final|" +
@@ -52,7 +52,7 @@ import java.net.URL;
         }
 )
 @OpenShiftResources({
-    @OpenShiftResource("https://raw.githubusercontent.com/jboss-openshift/application-templates/master/secrets/decisionserver-app-secret.json")
+    @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/decisionserver-app-secret.json")
 })
 public class DecisionServerHttpClientSecureAllInOneTest extends DecisionServerTestBase {
 

--- a/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerMultiContainerAmqTest.java
+++ b/kieserver/63/src/test/java/org/jboss/test/arquillian/ce/decisionserver/DecisionServerMultiContainerAmqTest.java
@@ -44,7 +44,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/decisionserver/decisionserver63-amq-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/decisionserver/decisionserver63-amq-s2i.json",
         parameters = {
                 //the Containers list will be sorted in alphabetical order
                 @TemplateParameter(name = "KIE_CONTAINER_DEPLOYMENT", value = "decisionserver-hellorules=org.openshift.quickstarts:decisionserver-hellorules:1.3.0.Final|" +

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -144,6 +144,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -135,6 +135,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64EnvTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64EnvTest.java
@@ -34,7 +34,7 @@ import org.jboss.arquillian.ce.cube.RouteURL;
 import org.jboss.arquillian.test.api.ArquillianResource;
 
 //@RunWith(Arquillian.class)
-//@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-sso-s2i.json",
+//@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-sso-s2i.json",
 //		labels = "application=eap-app",
 //		parameters = {
 //			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64LogTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64LogTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64SecureDeploymentsTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64SecureDeploymentsTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 				@TemplateParameter(name = "SOURCE_REPOSITORY_URL", value="https://github.com/jboss-openshift/openshift-examples"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64Test.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap64Test.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap64-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap64-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70EnvTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70EnvTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 //@RunWith(Arquillian.class)
-//@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap70-sso-s2i.json",
+//@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap70-sso-s2i.json",
 //		labels = "application=eap-app",
 //		parameters = {
 //			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70LogTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70LogTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap70-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap70-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70SecureDeploymentsTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70SecureDeploymentsTest.java
@@ -36,7 +36,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap70-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap70-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 				@TemplateParameter(name = "SOURCE_REPOSITORY_URL", value="https://github.com/jboss-openshift/openshift-examples"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70Test.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoEap70Test.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/eap/eap70-sso-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap70-sso-s2i.json",
 		labels = "application=eap-app",
 		parameters = {
 			@TemplateParameter(name = "HTTPS_NAME", value = "jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerBasicTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerBasicTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template( url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/sso/sso70-https.json",
+@Template( url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/sso/sso70-https.json",
 		labels = "application=sso",
 		parameters = {
 		        @TemplateParameter(name = "HTTPS_NAME", value="jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerLogTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerLogTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template( url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/sso/sso70-https.json",
+@Template( url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/sso/sso70-https.json",
 labels = "application=sso",
 parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value="jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerMysqlTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerMysqlTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/sso/sso70-mysql.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/sso/sso70-mysql.json",
 labels = "application=sso,component=server",
 parameters = {
         @TemplateParameter(name = "HTTPS_NAME", value="jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerPostgresqlPersistentTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerPostgresqlPersistentTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/sso/sso70-postgresql-persistent.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/sso/sso70-postgresql-persistent.json",
 		labels = "application=sso,component=server",
 		parameters = {
 		        @TemplateParameter(name = "HTTPS_NAME", value="jboss"),

--- a/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerPostgresqlTest.java
+++ b/sso/src/test/java/org/jboss/test/arquillian/ce/sso/SsoServerPostgresqlTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/sso/sso70-postgresql.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/sso/sso70-postgresql.json",
 		labels = "application=sso,component=server",
 		parameters = {
 		        @TemplateParameter(name = "HTTPS_NAME", value="jboss"),

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -131,6 +131,8 @@
                         <kubernetes.master>${kubernetes.master}</kubernetes.master>
                         <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
                         <arq.extension.ce-cube.routerHost>${router.hostIP}</arq.extension.ce-cube.routerHost>
+                        <template.repository>jboss-openshift</template.repository>
+                        <template.branch>master</template.branch>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicSecureTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicSecureTest.java
@@ -37,7 +37,7 @@ import java.net.URL;
  * @author fspolti
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat7-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-https-s2i.json",
         labels = "application=jws-app"
 )
 @ClientEndpoint

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicTest.java
@@ -41,7 +41,7 @@ import java.net.URL;
  * @author fspolti
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat7-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-basic-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbBasicTest.java
@@ -42,7 +42,7 @@ import java.net.URL;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat7-mongodb-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mongodb-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbPVTest.java
@@ -46,7 +46,7 @@ import java.util.List;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat7-mongodb-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mongodb-persistent-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbBasicTest.java
@@ -42,7 +42,7 @@ import java.net.URL;
 */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat7-mysql-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mysql-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbPVTest.java
@@ -46,7 +46,7 @@ import java.util.List;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat7-mysql-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mysql-persistent-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbBasicTest.java
@@ -42,7 +42,7 @@ import java.net.URL;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat7-postgresql-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-postgresql-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbPVTest.java
@@ -46,7 +46,7 @@ import java.util.List;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat7-postgresql-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-postgresql-persistent-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicSecureTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicSecureTest.java
@@ -37,7 +37,7 @@ import java.net.URL;
  * @author fspolti
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat8-https-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-https-s2i.json",
         labels = "application=jws-app"
 )
 @ClientEndpoint

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicTest.java
@@ -41,7 +41,7 @@ import java.net.URL;
  * @author fspolti
  */
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat8-basic-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-basic-s2i.json",
         labels = "application=jws-app"
 )
 @OpenShiftResources({

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbBasicTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat8-mongodb-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mongodb-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8MongoDbBasicTest extends WebServerTomcat7MongoDbBasicTest {

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbPVTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat8-mongodb-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mongodb-persistent-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8MongoDbPVTest extends WebServerTomcat7MongoDbPVTest {

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbBasicTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat8-mysql-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mysql-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8MySQLDbBasicTest extends WebServerTomcat7MySQLDbBasicTest {

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbPVTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat8-mysql-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mysql-persistent-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8MySQLDbPVTest extends WebServerTomcat7MySQLDbPVTest {

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbBasicTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://raw.githubusercontent.com/jboss-openshift/application-templates/master/webserver/jws30-tomcat8-postgresql-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-postgresql-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8PostgresqlDbBasicTest extends WebServerTomcat7PostgresqlDbBasicTest {

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbPVTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(Arquillian.class)
-@Template(url = "https://github.com/jboss-openshift/application-templates/raw/master/webserver/jws30-tomcat8-postgresql-persistent-s2i.json",
+@Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-postgresql-persistent-s2i.json",
         labels = "application=jws-app"
 )
 public class WebServerTomcat8PostgresqlDbPVTest extends WebServerTomcat7PostgresqlDbPVTest {


### PR DESCRIPTION
Make the repo owner (fork) and branch configurable
through properties template.repository and template.branch,
defaulting to what we use currently: 'jboss-openshift' and 'master'.

This allows we to run the tests against different versions of templates.