### PR TITLE
Fix S2I configuration for AmqSourceToImageTest

### DIFF
--- a/amq/src/test/resources/amq62-s2i.json
+++ b/amq/src/test/resources/amq62-s2i.json
@@ -278,7 +278,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "openshift",
-                            "name": "jboss-amq-62:1.4"
+                            "name": "jboss-amq-62:1.3"
                         }
                     }
                 },


### PR DESCRIPTION
The base image version for building is still wrong.
The latest version is 1.3, not 1.4.