### PR TITLE
Change A-MQ routes to use a dynamic host name for AmqExternalAccessTest

### DIFF
--- a/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqTestBase.java
+++ b/amq/src/test/java/org/jboss/test/arquillian/ce/amq/AmqTestBase.java
@@ -1,6 +1,7 @@
 package org.jboss.test.arquillian.ce.amq;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Properties;
 
 import org.jboss.arquillian.ce.api.OpenShiftHandle;
@@ -48,4 +49,16 @@ public class AmqTestBase {
         handler.scaleDeployment("amq-test-amq", 0);
         handler.scaleDeployment("amq-test-amq", 1);
     }
+    
+    protected String getRouteUrl(URL routeUrl, String scheme) {
+    	StringBuilder routeString = new StringBuilder();
+    	routeString.append(scheme);
+    	routeString.append("://");
+    	routeString.append(routeUrl.getHost());
+    	routeString.append(":");
+    	routeString.append(routeUrl.getPort());
+    	
+    	return routeString.toString();
+    }
+    
 }

--- a/amq/src/test/resources/amq-routes.json
+++ b/amq/src/test/resources/amq-routes.json
@@ -13,7 +13,6 @@
 		        }
 		    },
 		    "spec": {
-		        "host": "tcp-amq.router.default.svc.cluster.local",
 		        "to": {
 		            "kind": "Service",
 		            "name": "amq-test-amq-tcp-ssl"
@@ -37,7 +36,6 @@
 		        }
 		    },
 		    "spec": {
-		        "host": "amqp-amq.router.default.svc.cluster.local",
 		        "to": {
 		            "kind": "Service",
 		            "name": "amq-test-amq-amqp-ssl"
@@ -61,7 +59,6 @@
 		        }
 		    },
 		    "spec": {
-		        "host": "mqtt-amq.router.default.svc.cluster.local",
 		        "to": {
 		            "kind": "Service",
 		            "name": "amq-test-amq-mqtt-ssl"
@@ -85,7 +82,6 @@
 		        }
 		    },
 		    "spec": {
-		        "host": "stomp-amq.router.default.svc.cluster.local",
 		        "to": {
 		            "kind": "Service",
 		            "name": "amq-test-amq-stomp-ssl"


### PR DESCRIPTION
Fixes #149. This reflect in issues when running the same A-MQ suite in the same Openshift instance but with different namespaces.