### PR TITLE
Fix webserver tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <module>kieserver</module>
         <module>spark</module>
         <!-- <module>sso</module> -->
-        <!-- <module>webserver</module> -->
+        <module>webserver</module>
     </modules>
 
     <build>

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicSecureTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicSecureTest.java
@@ -23,15 +23,18 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
+import java.net.URL;
+
+import javax.websocket.ClientEndpoint;
+
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
 import org.jboss.arquillian.ce.cube.RouteURL;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.websocket.ClientEndpoint;
-import java.net.URL;
 
 /**
  * @author fspolti
@@ -40,8 +43,11 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-https-s2i.json",
         labels = "application=jws-app"
 )
+@OpenShiftResources({
+    @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
 @ClientEndpoint
-public class WebServerTomcat7BasicSecureTest extends WebServerTomcat7BasicTest {
+public class WebServerTomcat7BasicSecureTest extends WebserverTestBase {
 
     @Test
     @RunAsClient

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7BasicTest.java
@@ -23,19 +23,16 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
-import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.net.URL;
 
 import javax.websocket.ClientEndpoint;
-import java.net.URL;
+
+import org.jboss.arquillian.ce.api.Template;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author fspolti
@@ -44,16 +41,8 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-basic-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
 @ClientEndpoint
 public class WebServerTomcat7BasicTest extends WebserverTestBase {
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
 
     @Test
     @RunAsClient

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbBasicTest.java
@@ -23,19 +23,9 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 /**
  * @author fspolti
@@ -45,46 +35,6 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mongodb-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7MongoDbBasicTest extends WebserverTestBase {
+public class WebServerTomcat7MongoDbBasicTest extends WebServerTomcatMongoDbBasicTestBase {
 
-    private final String summary = "Testing MongoDB Todo list";
-    private final String summaryHttps = "Testing MongoDB Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testMongoDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testMongoDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testMongoDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testMongoDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MongoDbPVTest.java
@@ -23,23 +23,9 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftHandle;
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author fspolti
@@ -49,76 +35,6 @@ import java.util.List;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mongodb-persistent-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7MongoDbPVTest extends WebserverTestBase {
+public class WebServerTomcat7MongoDbPVTest extends WebServerTomcatMongoDbPVTestBase {
 
-    private final String summary = "Testing Persistent MongoDB Todo list";
-    private final String summaryHttps = "Testing Persistent MongoDB Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using HTTP using Persistent storage.";
-
-    @ArquillianResource
-    private OpenShiftHandle adapter;
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testMongoDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testMongoDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testMongoDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testMongoDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(5)
-    public void restartDatabasePods() throws Exception {
-        List<String> pods = new ArrayList<>();
-        pods.add("jws-app-mongodb");
-        pods.add("jws-app");
-        restartPods(adapter, pods);
-    }
-
-    /*
-    * After restart the pods we have to test it again to make sure the data stored before still there
-    */
-    @Test
-    @RunAsClient
-    @InSequence(6)
-    public void testMongoDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(7)
-    public void testMongoDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbBasicTest.java
@@ -23,68 +23,18 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 /**
  * @author fspolti
-*/
+ */
 
 @RunWith(Arquillian.class)
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mysql-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7MySQLDbBasicTest extends WebserverTestBase {
+public class WebServerTomcat7MySQLDbBasicTest extends WebServerTomcatMySQLDbBasicTestBase {
 
-    private final String summary = "Testing MySQL Todo list";
-    private final String summaryHttps = "Testing MySQL Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testMySQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testMySQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testMySQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testMySQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7MySQLDbPVTest.java
@@ -23,23 +23,9 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftHandle;
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author fspolti
@@ -49,76 +35,6 @@ import java.util.List;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-mysql-persistent-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7MySQLDbPVTest extends WebserverTestBase {
+public class WebServerTomcat7MySQLDbPVTest extends WebServerTomcatMySQLDbPVTestBase {
 
-    private final String summary = "Testing Persistent MySQL Todo list";
-    private final String summaryHttps = "Testing Persistent MySQL Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using Persistent storage.";
-
-    @ArquillianResource
-    private OpenShiftHandle adapter;
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testMySQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testMySQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testMySQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testMySQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(5)
-    public void restartDatabasePods() throws Exception {
-        List<String> pods = new ArrayList<>();
-        pods.add("jws-app-mysql");
-        pods.add("jws-app");
-        restartPods(adapter, pods);
-    }
-
-    /*
-    * After restart the pods we have to test it again to make sure the data stored before still there
-    */
-    @Test
-    @RunAsClient
-    @InSequence(6)
-    public void testMySQLDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(7)
-    public void testMySQLDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbBasicTest.java
@@ -23,19 +23,9 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 /**
  * @author fspolti
@@ -45,46 +35,6 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-postgresql-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7PostgresqlDbBasicTest extends WebserverTestBase {
+public class WebServerTomcat7PostgresqlDbBasicTest extends WebServerTomcatPostgresqlDbBasicTestBase {
 
-    private final String summary = "Testing PostgreSQL Todo list";
-    private final String summaryHttps = "Testing PostgreSQL Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testPostgreSQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testPostgreSQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testPostgreSQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testPostgreSQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat7PostgresqlDbPVTest.java
@@ -23,23 +23,9 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftHandle;
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author fspolti
@@ -49,76 +35,6 @@ import java.util.List;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat7-postgresql-persistent-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
-public class WebServerTomcat7PostgresqlDbPVTest extends WebserverTestBase {
+public class WebServerTomcat7PostgresqlDbPVTest extends WebServerTomcatPostgresqlDbPVTestBase {
 
-    private final String summary = "Testing Persistent PostgreSQL Todo list";
-    private final String summaryHttps = "Testing Persistent PostgreSQL Todo list HTTPS";
-    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
-    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using Persistent storage.";
-
-    @ArquillianResource
-    private OpenShiftHandle adapter;
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(1)
-    public void testPostgreSQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(2)
-    public void testPostgreSQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(3)
-    public void testPostgreSQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(4)
-    public void testPostgreSQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(5)
-    public void restartDatabasePods() throws Exception {
-        List<String> pods = new ArrayList<>();
-        pods.add("jws-app-postgresql");
-        pods.add("jws-app");
-        restartPods(adapter, pods);
-    }
-
-    /*
-    * After restart the pods we have to test it again to make sure the data stored before still there
-    */
-    @Test
-    @RunAsClient
-    @InSequence(6)
-    public void testPostgreSQLDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summary, description);
-    }
-
-    @Test
-    @RunAsClient
-    @InSequence(7)
-    public void testPostgreSQLDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
-        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
-    }
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicSecureTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicSecureTest.java
@@ -23,15 +23,18 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
+import java.net.URL;
+
+import javax.websocket.ClientEndpoint;
+
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
 import org.jboss.arquillian.ce.api.Template;
 import org.jboss.arquillian.ce.cube.RouteURL;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.websocket.ClientEndpoint;
-import java.net.URL;
 
 /**
  * @author fspolti
@@ -40,8 +43,11 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-https-s2i.json",
         labels = "application=jws-app"
 )
+@OpenShiftResources({
+    @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
 @ClientEndpoint
-public class WebServerTomcat8BasicSecureTest extends WebServerTomcat8BasicTest {
+public class WebServerTomcat8BasicSecureTest extends WebserverTestBase {
 
     @Test
     @RunAsClient

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8BasicTest.java
@@ -23,19 +23,16 @@
 
 package org.jboss.test.arquillian.ce.webserver;
 
-import org.jboss.arquillian.ce.api.OpenShiftResource;
-import org.jboss.arquillian.ce.api.OpenShiftResources;
-import org.jboss.arquillian.ce.api.Template;
-import org.jboss.arquillian.ce.cube.RouteURL;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.net.URL;
 
 import javax.websocket.ClientEndpoint;
-import java.net.URL;
+
+import org.jboss.arquillian.ce.api.Template;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author fspolti
@@ -44,16 +41,8 @@ import java.net.URL;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-basic-s2i.json",
         labels = "application=jws-app"
 )
-@OpenShiftResources({
-        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
-})
 @ClientEndpoint
 public class WebServerTomcat8BasicTest extends WebserverTestBase {
-
-    @Deployment
-    public static WebArchive getDeployment() throws Exception {
-        return getDeploymentInternal();
-    }
 
     @Test
     @RunAsClient

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbBasicTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mongodb-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8MongoDbBasicTest extends WebServerTomcat7MongoDbBasicTest {
+public class WebServerTomcat8MongoDbBasicTest extends WebServerTomcatMongoDbBasicTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MongoDbPVTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mongodb-persistent-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8MongoDbPVTest extends WebServerTomcat7MongoDbPVTest {
+public class WebServerTomcat8MongoDbPVTest extends WebServerTomcatMongoDbPVTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbBasicTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mysql-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8MySQLDbBasicTest extends WebServerTomcat7MySQLDbBasicTest {
+public class WebServerTomcat8MySQLDbBasicTest extends WebServerTomcatMySQLDbBasicTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8MySQLDbPVTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-mysql-persistent-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8MySQLDbPVTest extends WebServerTomcat7MySQLDbPVTest {
+public class WebServerTomcat8MySQLDbPVTest extends WebServerTomcatMySQLDbPVTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbBasicTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbBasicTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-postgresql-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8PostgresqlDbBasicTest extends WebServerTomcat7PostgresqlDbBasicTest {
+public class WebServerTomcat8PostgresqlDbBasicTest extends WebServerTomcatPostgresqlDbBasicTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbPVTest.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcat8PostgresqlDbPVTest.java
@@ -35,6 +35,6 @@ import org.junit.runner.RunWith;
 @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/webserver/jws30-tomcat8-postgresql-persistent-s2i.json",
         labels = "application=jws-app"
 )
-public class WebServerTomcat8PostgresqlDbPVTest extends WebServerTomcat7PostgresqlDbPVTest {
+public class WebServerTomcat8PostgresqlDbPVTest extends WebServerTomcatPostgresqlDbPVTestBase {
 
 }

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMongoDbBasicTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMongoDbBasicTestBase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+ */
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public abstract class WebServerTomcatMongoDbBasicTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing MongoDB Todo list";
+    private final String summaryHttps = "Testing MongoDB Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testMongoDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testMongoDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testMongoDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testMongoDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMongoDbPVTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMongoDbPVTestBase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.ce.api.OpenShiftHandle;
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+ */
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public class WebServerTomcatMongoDbPVTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing Persistent MongoDB Todo list";
+    private final String summaryHttps = "Testing Persistent MongoDB Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using HTTP using Persistent storage.";
+
+    @ArquillianResource
+    private OpenShiftHandle adapter;
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testMongoDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testMongoDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testMongoDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testMongoDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(5)
+    public void restartDatabasePods() throws Exception {
+        List<String> pods = new ArrayList<>();
+        pods.add("jws-app-mongodb");
+        pods.add("jws-app");
+        restartPods(adapter, pods);
+    }
+
+    /*
+    * After restart the pods we have to test it again to make sure the data stored before still there
+    */
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void testMongoDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void testMongoDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMySQLDbBasicTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMySQLDbBasicTestBase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+*/
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public class WebServerTomcatMySQLDbBasicTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing MySQL Todo list";
+    private final String summaryHttps = "Testing MySQL Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testMySQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testMySQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testMySQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testMySQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMySQLDbPVTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatMySQLDbPVTestBase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.ce.api.OpenShiftHandle;
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+ */
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public class WebServerTomcatMySQLDbPVTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing Persistent MySQL Todo list";
+    private final String summaryHttps = "Testing Persistent MySQL Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using Persistent storage.";
+
+    @ArquillianResource
+    private OpenShiftHandle adapter;
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testMySQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testMySQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testMySQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testMySQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(5)
+    public void restartDatabasePods() throws Exception {
+        List<String> pods = new ArrayList<>();
+        pods.add("jws-app-mysql");
+        pods.add("jws-app");
+        restartPods(adapter, pods);
+    }
+
+    /*
+    * After restart the pods we have to test it again to make sure the data stored before still there
+    */
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void testMySQLDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void testMySQLDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatPostgresqlDbBasicTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatPostgresqlDbBasicTestBase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+ */
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public class WebServerTomcatPostgresqlDbBasicTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing PostgreSQL Todo list";
+    private final String summaryHttps = "Testing PostgreSQL Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS.";
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testPostgreSQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testPostgreSQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testPostgreSQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testPostgreSQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatPostgresqlDbPVTestBase.java
+++ b/webserver/src/test/java/org/jboss/test/arquillian/ce/webserver/WebServerTomcatPostgresqlDbPVTestBase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.arquillian.ce.webserver;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.ce.api.OpenShiftHandle;
+import org.jboss.arquillian.ce.api.OpenShiftResource;
+import org.jboss.arquillian.ce.api.OpenShiftResources;
+import org.jboss.arquillian.ce.cube.RouteURL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+/**
+ * @author fspolti
+ */
+
+@OpenShiftResources({
+        @OpenShiftResource("https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/secrets/jws-app-secret.json")
+})
+public class WebServerTomcatPostgresqlDbPVTestBase extends WebserverTestBase {
+
+    private final String summary = "Testing Persistent PostgreSQL Todo list";
+    private final String summaryHttps = "Testing Persistent PostgreSQL Todo list HTTPS";
+    private final String description = "This todo was added by Arquillian Test using HTTP using Persistent storage.";
+    private final String descriptionHttps = "This todo was added by Arquillian Test using HTTPS using Persistent storage.";
+
+    @ArquillianResource
+    private OpenShiftHandle adapter;
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        return getDeploymentInternal();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void testPostgreSQLDBTodoListAddItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void testPostgreSQLDBTodoListAddItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(3)
+    public void testPostgreSQLDBTodoListAddedItems(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(4)
+    public void testPostgreSQLDBTodoListAddedItemsSecure(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(5)
+    public void restartDatabasePods() throws Exception {
+        List<String> pods = new ArrayList<>();
+        pods.add("jws-app-postgresql");
+        pods.add("jws-app");
+        restartPods(adapter, pods);
+    }
+
+    /*
+    * After restart the pods we have to test it again to make sure the data stored before still there
+    */
+    @Test
+    @RunAsClient
+    @InSequence(6)
+    public void testPostgreSQLDBTodoListAddedItemsAfterPodsRestart(@RouteURL("jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summary, description);
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(7)
+    public void testPostgreSQLDBTodoListAddedItemsSecureAfterPodsRestart(@RouteURL("secure-jws-app") URL url) throws Exception {
+        checkTodoListAddedItems(url.toString(),summaryHttps, descriptionHttps);
+    }
+}

--- a/webserver/src/test/resources/arquillian.xml
+++ b/webserver/src/test/resources/arquillian.xml
@@ -54,7 +54,6 @@
         <!-- Pod running remote tests. -->
         <configuration>
             <!-- For use with archillian-chameleon -->
-            <property name="target">jboss eap:6.4.5:remote</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>

--- a/webserver/src/test/resources/testrunner-pod.json
+++ b/webserver/src/test/resources/testrunner-pod.json
@@ -16,11 +16,11 @@
 					"command": [
 					    "/bin/bash",
 					    "-c",
-					    "curl -s --digest -L http://localhost:9990/management --header \"Content-Type: application/json\" -d '{\"operation\":\"read-attribute\",\"name\":\"server-state\",\"json.pretty\":1}' | grep -iq running"
+					    "/opt/eap/bin/readinessProbe.sh"
 					]
 				}
 			},
-			"image": "jboss-eap-6/eap64-openshift:1.2",
+			"image": "jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,


### PR DESCRIPTION
- Refactor some test classes to only have @Template annotation
  on the most down class in the hierarchy. This avoids ce-arq
  to instantiate multiple templates.
- Fix testrunner pod image tag and readiness probe
- Enable webserver module in parent pom