### PR TITLE
Disable kieserver 6.2 tests

### DIFF
--- a/kieserver/pom.xml
+++ b/kieserver/pom.xml
@@ -19,7 +19,7 @@
     <description>Decision Server Cloud Enablement Testsuite</description>
 
     <modules>
-        <module>62</module>
+	<!-- <module>62</module> -->
         <module>63</module>
     </modules>
 


### PR DESCRIPTION
This is not a supported product, it's deprecated.
Let's keep them around for a while before removing them.