### PR TITLE
Use the latest eap 6.4 images for testrunner pod

### DIFF
--- a/jdg/jdg65/src/test/resources/testrunner-pod.json
+++ b/jdg/jdg65/src/test/resources/testrunner-pod.json
@@ -20,7 +20,7 @@
 					]
 				}
 			},
-			"image": "jboss-eap-6/eap64-openshift:1.2",
+			"image": "jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,

--- a/spark/src/test/resources/testrunner-pod.json
+++ b/spark/src/test/resources/testrunner-pod.json
@@ -20,7 +20,7 @@
 					]
 				}
 			},
-			"image": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.2",
+			"image": "registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.4",
             "ports": [
                 {
                     "containerPort": 8080,


### PR DESCRIPTION
1.2 is ancient and is not available on some registries.