### PR TITLE
Disable Web Console tests on EAP 7 integration tests

### DIFF
--- a/eap/integration/eap7/pom.xml
+++ b/eap/integration/eap7/pom.xml
@@ -1220,6 +1220,9 @@
 
                         <!-- tries to open a port on local host instead the pod -->
                         <exclude>**/JMXConnectorTestCase.java</exclude>
+
+                        <!-- web console is disabled on EAP images -->
+                        <exclude>**/WebConsoleSecurityTestCase.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Our images does not have the web console enabled, so this tests
are not needed.