### PR TITLE
Fix hanging jdg tests

### DIFF
--- a/jdg/jdg65/pom.xml
+++ b/jdg/jdg65/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <!-- Parent -->
     <parent>
@@ -17,9 +17,10 @@
     <packaging>jar</packaging>
     <name>JDG 6.5 CE Testsuite</name>
     <description>JDG 6.5 Cloud Enablement Testsuite</description>
-    
+
     <properties>
         <version.spymemcached>2.8.1</version.spymemcached>
+        <version.commons.collections>3.2.2.redhat-2</version.commons.collections>
     </properties>
 
     <dependencies>
@@ -115,6 +116,11 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>${version.commons.collections}</version>
+        </dependency>
 
     </dependencies>
 
@@ -170,7 +176,3 @@
         </plugins>
     </build>
 </project>
-
-
-
-

--- a/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgTestSecureBase.java
+++ b/jdg/jdg65/src/test/java/org/jboss/test/arquillian/ce/jdg/JdgTestSecureBase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URL;
 
+import org.apache.commons.collections.list.CursorableLinkedList;
 import org.jboss.arquillian.ce.api.Tools;
 import org.jboss.arquillian.ce.cube.RouteURL;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -40,7 +41,7 @@ public abstract class JdgTestSecureBase extends JdgTestBase {
     protected static WebArchive getDeploymentInternal() {
         WebArchive war = JdgTestBase.getDeploymentInternal();
         war.addClass(JdgTestSecureBase.class);
-
+        war.addClass(CursorableLinkedList.class);
         return war;
     }
     @Test


### PR DESCRIPTION
When undeploying the runinpod.war an CNF can happen making the test hang
in the undeploy process. CNF:
ERROR [stderr] (Timer-1) Caused by: java.lang.ClassNotFoundException: org.apache.commons.pool.impl.CursorableLinkedList$Cursor from [Module "deployment.run-in-pod.war:main" from Service Module Loader]