### PR TITLE
CNF when trying to undeploy the runinpod.war

### DIFF
--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqBase.java
@@ -23,6 +23,7 @@
 
 package org.jboss.test.arquillian.ce.amq.support;
 
+import org.fusesource.mqtt.codec.PINGREQ;
 import org.jboss.arquillian.ce.api.OpenShiftHandle;
 import org.jboss.arquillian.ce.api.Tools;
 import org.jboss.arquillian.ce.shrinkwrap.Files;
@@ -48,6 +49,7 @@ public class AmqBase {
         war.addClass(AmqClient.class);
         war.addClass(AmqPersistentTestBase.class);
         war.addClass(AmqTestBase.class);
+        war.addClass(PINGREQ.class);
         war.addClasses(classes);
 
         war.addAsLibraries(Libraries.transitive("org.apache.activemq", "activemq-client"));


### PR DESCRIPTION
Sometimes the undeploy process of arquillian services fails
due a CNF for the class org.fusesource.mqtt.codec.PINGREQ leading the
undeploy process to hang.