### PR TITLE
Adapt the testsuite for the new ce-arq/arq-cube

### DIFF
--- a/amq/62/src/test/resources/arquillian.xml
+++ b/amq/62/src/test/resources/arquillian.xml
@@ -28,17 +28,13 @@
     
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-amq62</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-amq62</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/amq/63/src/test/resources/arquillian.xml
+++ b/amq/63/src/test/resources/arquillian.xml
@@ -28,17 +28,14 @@
     
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-amq63</property>
-    </extension>
-  
+
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-amq63</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/datavirt/src/test/resources/arquillian.xml
+++ b/datavirt/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-datavirt</property>
-    </extension>
   
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-jdv</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/eap/eap64/src/test/resources/arquillian.xml
+++ b/eap/eap64/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-eap64</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-eap64</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/eap/eap70/src/test/resources/arquillian.xml
+++ b/eap/eap70/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-eap70</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-eap70</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/eap/integration/eap6/src/test/resources/arquillian.xml
+++ b/eap/integration/eap6/src/test/resources/arquillian.xml
@@ -26,16 +26,12 @@
     </engine>
     -->
 
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-integration-eap6</property>
-    </extension>
-
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-integration-eap6</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> or <container>:0:<port>, to map the same port than container use <container>::<port> or <container>:<port>:<port> -->

--- a/eap/integration/eap7/src/test/resources/arquillian.xml
+++ b/eap/integration/eap7/src/test/resources/arquillian.xml
@@ -27,16 +27,12 @@
     <!--<property name="deploymentExportPath">/tmp/</property>-->
     <!--</engine>-->
 
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-integration-eap7</property>
-    </extension>
-
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-integration-eap7</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> or <container>:0:<port>, to map the same port than container use <container>::<port> or <container>:<port>:<port> -->

--- a/jdg/integration/src/test/resources/arquillian.xml
+++ b/jdg/integration/src/test/resources/arquillian.xml
@@ -3,11 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-	<extension qualifier="ce-cube">
-		<property name="kubernetesNamespacePrefix">cearq-integration-jdg6</property>
-	</extension>
-
 	<extension qualifier="openshift">
+		<property name="namespace.prefix">cearq-integration-jdg6</property>
 		<property name="definitionsFile">${definitions.file}</property>
 		<!-- Ports to be proxied locally, <container>:<port> or <container>:0:<port>, to map the same port than container use <container>::<port> or <container>:<port>:<port> -->
 		<property name="proxiedContainerPorts">container1::8080,container1::9999,container1::11211,container1::11222,container2:8180:8080,container2:10099:9999,container2:11311:11211,container2:11322:11322</property>

--- a/jdg/jdg65/src/test/resources/arquillian.xml
+++ b/jdg/jdg65/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-jdg65</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-jdg65</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/kieserver/62/src/test/resources/arquillian.xml
+++ b/kieserver/62/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-kie62</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-kie62</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/kieserver/63/src/test/resources/arquillian.xml
+++ b/kieserver/63/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-kie63</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-kie63</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/kieserver/64/src/test/resources/arquillian.xml
+++ b/kieserver/64/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-kie64</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-kie64</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 
     <!-- Properties -->
     <properties>
-        <version.ce-arq>1.0.1.Final</version.ce-arq>
+        <version.ce-arq>1.1.0.Final</version.ce-arq>
         <version.meta-inf>1.6</version.meta-inf>
-        <version.arquillian>1.1.11.Final</version.arquillian>
+        <version.arquillian>1.1.13.Final</version.arquillian>
         <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
         <version.arquillian.governor>1.0.1.Final</version.arquillian.governor>
         <version.eap6>7.5.16.Final-redhat-ce</version.eap6> <!--eap 6.4.x downstream -->

--- a/spark/src/test/resources/arquillian.xml
+++ b/spark/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-spark</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-spark</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/sso/src/test/resources/arquillian.xml
+++ b/sso/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-sso</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-sso</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->

--- a/webserver/src/test/resources/arquillian.xml
+++ b/webserver/src/test/resources/arquillian.xml
@@ -27,17 +27,13 @@
     -->
     <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
     <defaultProtocol type="jmx-as7" />
-    
-    <extension qualifier="ce-cube">
-        <property name="kubernetesNamespacePrefix">cearq-jws</property>
-    </extension>
-  
+
     <!-- Example configuration for arquillian openshift extension -->
     <extension qualifier="openshift">
         <!-- Properties describing the location of the OpenShift instance.
         <property name="originServer">https://your-ose-instance.com:8443</property>
-        <property name="namespace">test-namespace</property>
         -->
+        <property name="namespace.prefix">cearq-jws</property>
         <!-- The file containing the pod definition. Used to instantiate the JBoss instance. -->
         <property name="definitionsFile">src/test/resources/testrunner-pod.json</property>
         <!-- Ports to be proxied locally, <container>:<port> -->


### PR DESCRIPTION
The namespace configuration has changed and it is done under openshift qualifier.