### PR TITLE
bump remoting3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <api-ldap-client-all.version>1.0.0-M33</api-ldap-client-all.version>
         <apacheds-server-annotations.version>2.0.0-M21</apacheds-server-annotations.version>
         <version.amq.ce.common>1.0.0-SNAPSHOT</version.amq.ce.common>
+        <version.org.jboss.remoting3>3.3.10.Final</version.org.jboss.remoting3>
     </properties>
 
     <modules>
@@ -174,6 +175,13 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.remoting3</groupId>
+                <artifactId>jboss-remoting</artifactId>
+                <version>${version.org.jboss.remoting3}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
The version of remoting3 used on the testsuite has a bug that make the tests, sometimes, hang
during the undploy of the arquillian resource after the tests execution.
In the thread dump of a frozen test we can find this locked object:

	at org.jboss.remoting3.spi.AbstractHandleableCloseable.close(AbstractHandleableCloseable.java:177)
	- locked <0x0000000782f555d8> (a java.lang.Object)

This particular issue was fixed by this commit:
https://github.com/jboss-remoting/jboss-remoting/commit/83c882697d8b01f8262c8efb17e1b0e2eb3a7c61

which is available in the version present in this commit.