### PR TITLE
Update the deploymentConfig label

### DIFF
--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqBase.java
@@ -66,10 +66,10 @@ public class AmqBase {
     }
 
     protected static void restartAmq(OpenShiftHandle handler) throws Exception {
-        handler.scaleDeployment("amq-test-amq", 0);
-        handler.waitForReadyPods("amq-test-amq", 0);
-        handler.scaleDeployment("amq-test-amq", 1);
-        handler.waitForReadyPods("amq-test-amq", 1);
+        handler.scaleDeployment("amq-test", 0);
+        handler.waitForReadyPods("amq-test", 0);
+        handler.scaleDeployment("amq-test", 1);
+        handler.waitForReadyPods("amq-test", 1);
     }
 
     protected AmqClient createAmqClient(String url) throws Exception {

--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqFillDataDirTestBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqFillDataDirTestBase.java
@@ -62,7 +62,7 @@ public class AmqFillDataDirTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(1)
     public void testWaitForPods(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.waitForReadyPods("amq-test-amq", 1);
+        adapter.waitForReadyPods("amq-test", 1);
     }
 
     @Test
@@ -75,7 +75,7 @@ public class AmqFillDataDirTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(3)
     public void testScale(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        Collection<String> pods = adapter.getPods("amq-test-amq");
+        Collection<String> pods = adapter.getPods("amq-test");
         Assert.assertEquals(1, pods.size()); // there should be only one
         String firstPod = pods.iterator().next(); // we put the msgs here
 
@@ -85,10 +85,10 @@ public class AmqFillDataDirTestBase extends AmqMigrationTestBase {
         String log = adapter.getLog(firstPod);
         int count = parseCount(log);
 
-        adapter.scaleDeployment("amq-test-amq", 2); // scale up
+        adapter.scaleDeployment("amq-test", 2); // scale up
 
         String sndPod = null;
-        pods = adapter.getReadyPods("amq-test-amq");
+        pods = adapter.getReadyPods("amq-test");
         for (String podName : pods) {
             if (podName.equals(firstPod) == false) {
                 sndPod = podName;
@@ -99,9 +99,9 @@ public class AmqFillDataDirTestBase extends AmqMigrationTestBase {
 
         adapter.deletePod(firstPod, -1); // kill first, RC should re-use data dir
 
-        adapter.waitForReadyPods("amq-test-amq", 2);
+        adapter.waitForReadyPods("amq-test", 2);
 
-        pods = adapter.getReadyPods("amq-test-amq");
+        pods = adapter.getReadyPods("amq-test");
         for (String podName : pods) {
             if (podName.equals(sndPod) == false) {
                 int count2 = parseCount(adapter.getLog(podName));

--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqMeshTestBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqMeshTestBase.java
@@ -54,8 +54,8 @@ public class AmqMeshTestBase extends AmqBase {
     @RunAsClient
     @InSequence(1)
     public void scaleUpResources(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.scaleDeployment("amq-test-amq", 2);
-        adapter.waitForReadyPods("amq-test-amq", 2);
+        adapter.scaleDeployment("amq-test", 2);
+        adapter.waitForReadyPods("amq-test", 2);
         pods.addAll(adapter.getPods());
 
         log.info("Pods used for test: " + pods.toString());

--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqNMigrationsTestBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqNMigrationsTestBase.java
@@ -50,8 +50,8 @@ public class AmqNMigrationsTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(1)
     public void testScaleUp(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.scaleDeployment("amq-test-amq", REPLICAS);
-        adapter.waitForReadyPods("amq-test-amq", REPLICAS);
+        adapter.scaleDeployment("amq-test", REPLICAS);
+        adapter.waitForReadyPods("amq-test", REPLICAS);
     }
 
     @Test
@@ -67,7 +67,7 @@ public class AmqNMigrationsTestBase extends AmqMigrationTestBase {
         final int N = 10;
 
         for (int i = 0; i < N; i++) {
-            List<String> pods = new ArrayList<>(adapter.getReadyPods("amq-test-amq"));
+            List<String> pods = new ArrayList<>(adapter.getReadyPods("amq-test"));
             int pi;
             for (pi = 0; pi < pods.size(); pi++) {
                 String pod = pods.get(pi);
@@ -82,7 +82,7 @@ public class AmqNMigrationsTestBase extends AmqMigrationTestBase {
             log.info(String.format("Deleting pod: %s", pods.get(pi)));
             adapter.deletePod(pods.get(pi), -1);
 
-            adapter.waitForReadyPods("amq-test-amq", REPLICAS);
+            adapter.waitForReadyPods("amq-test", REPLICAS);
         }
     }
 

--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqQueueMigrationTestBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqQueueMigrationTestBase.java
@@ -40,8 +40,8 @@ public class AmqQueueMigrationTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(1)
     public void testScaleUp(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.scaleDeployment("amq-test-amq", 2); // scale up
-        adapter.waitForReadyPods("amq-test-amq", 2);
+        adapter.scaleDeployment("amq-test", 2); // scale up
+        adapter.waitForReadyPods("amq-test", 2);
     }
 
     @Test
@@ -56,8 +56,8 @@ public class AmqQueueMigrationTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(3)
     public void testScaleDown(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.scaleDeployment("amq-test-amq", 1); // scale down
-        adapter.waitForReadyPods("amq-test-amq", 1);
+        adapter.scaleDeployment("amq-test", 1); // scale down
+        adapter.waitForReadyPods("amq-test", 1);
 
         // drain should kick-in in any case
         Assert.assertNotEquals("Migration should have finished", -1, waitForDrain(adapter, 0, true, END));

--- a/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqRollingUpgradeTestBase.java
+++ b/amq/common/src/main/java/org/jboss/test/arquillian/ce/amq/support/AmqRollingUpgradeTestBase.java
@@ -44,8 +44,8 @@ public class AmqRollingUpgradeTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(1)
     public void testScaleUp(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        adapter.scaleDeployment("amq-test-amq", N);
-        adapter.waitForReadyPods("amq-test-amq", N);
+        adapter.scaleDeployment("amq-test", N);
+        adapter.waitForReadyPods("amq-test", N);
     }
 
     @Test
@@ -58,15 +58,15 @@ public class AmqRollingUpgradeTestBase extends AmqMigrationTestBase {
     @RunAsClient
     @InSequence(3)
     public void testRollingUpdate(@ArquillianResource OpenShiftHandle adapter) throws Exception {
-        final List<String> origPods = adapter.getPods("amq-test-amq");
+        final List<String> origPods = adapter.getPods("amq-test");
 
-        adapter.triggerDeploymentConfigUpdate("amq-test-amq", true);
+        adapter.triggerDeploymentConfigUpdate("amq-test", true);
 
         final long endTime = System.currentTimeMillis() + TIMEOUT;
 
         boolean upgradeFinished = false;
         while(!upgradeFinished && (System.currentTimeMillis() < endTime)) {
-            final List<String> pods = adapter.getPods("amq-test-amq");
+            final List<String> pods = adapter.getPods("amq-test");
             pods.removeAll(origPods);
             if (pods.size() == N) {
                 upgradeFinished = true;

--- a/eap/common/src/main/java/org/jboss/test/arquillian/ce/eap/common/EapAmqTestBase.java
+++ b/eap/common/src/main/java/org/jboss/test/arquillian/ce/eap/common/EapAmqTestBase.java
@@ -58,11 +58,11 @@ public class EapAmqTestBase {
         final int TRIES = 5;
 
         HashMap<String, String> labels = new HashMap<String, String>();
-        labels.put("deploymentConfig", "eap-app");
+        labels.put("deploymentconfig", "eap-app");
 
         int i = 0;
         while (i < TRIES) {
-            String podLog = adapter.getLog("eap-app-1", labels);
+            String podLog = adapter.getLog("eap-app", labels);
             if (messagesExist(podLog, prefix))
                 break;
             Thread.sleep(5 * 1000);


### PR DESCRIPTION
CLOUD-1167 removed the duplicated label deploymentConfig because Openshift
already add it itself, but all in lower case, deploymentconfig.